### PR TITLE
fix: patched db undefined bug

### DIFF
--- a/hono/src/utils/injectDB.ts
+++ b/hono/src/utils/injectDB.ts
@@ -15,6 +15,6 @@ export function createDB(c: Context) {
 }
 
 export default async function injectDB(c: Context, next: Function) {
-  c.set('db', createDB)
+  c.set('db', createDB(c))
   await next()
 }


### PR DESCRIPTION
"That was easy." Forgot to actually call the function `createDB()` with args when decomposing the middleware. Closes #46.