### PR TITLE
feat: modded alg to stop recommending outfits with the same core items

### DIFF
--- a/hono/src/services/outfits.ts
+++ b/hono/src/services/outfits.ts
@@ -309,7 +309,7 @@ app.get('/suggest', zValidator('query', suggestionsValidation), injectDB, async 
     const recentlyWornCount = outfit.recentlyWornItemCount as number
     const similarity_penalty = (() => {
       if (recentlyWornCount === 0) return 0
-      
+
       // Exponential penalty based on number of recently worn items
       // 1 item: -20, 2 items: -45, 3 items: -80, 4+ items: -125
       const basePenalty = -20
@@ -332,13 +332,15 @@ app.get('/suggest', zValidator('query', suggestionsValidation), injectDB, async 
     // First, group outfits by their core items and keep only the most recent one
     .reduce((acc, outfit) => {
       const coreItemsKey = (outfit.coreItems as string[])
-        .filter(id => id) // Remove any null/undefined values
+        .filter((id) => id) // Remove any null/undefined values
         .sort()
         .join('|')
 
       // Only keep this outfit if it's more recent than existing one with same core items
-      if (!acc.has(coreItemsKey) || 
-          new Date(outfit.lastWorn as string) > new Date(acc.get(coreItemsKey)!.lastWorn as string)) {
+      if (
+        !acc.has(coreItemsKey) ||
+        new Date(outfit.lastWorn as string) > new Date(acc.get(coreItemsKey)!.lastWorn as string)
+      ) {
         acc.set(coreItemsKey, outfit)
       }
       return acc
@@ -346,7 +348,7 @@ app.get('/suggest', zValidator('query', suggestionsValidation), injectDB, async 
     .values()
 
   // Convert to array and calculate scores
-  const uniqueOutfits = [...scoredOutfits].map(outfit => ({
+  const uniqueOutfits = [...scoredOutfits].map((outfit) => ({
     outfitId: outfit.id,
     score: Object.values(calculateScores(outfit)).reduce((a, b) => a + b, 0),
   }))

--- a/hono/src/services/outfits.ts
+++ b/hono/src/services/outfits.ts
@@ -232,7 +232,7 @@ app.get('/suggest', zValidator('query', suggestionsValidation), injectDB, async 
               SELECT 1
               FROM outfits o2
               JOIN items_to_outfits io2 ON io2.outfit_id = o2.id
-              WHERE o2.wear_date > NOW() - INTERVAL '${recencyThreshold} days'
+              WHERE o2.wear_date > NOW() - make_interval(days => ${recencyThreshold})
                 AND io2.item_id = io1.item_id
             )
         )::integer

--- a/hono/test/smoke/outfits.smoke.test.ts
+++ b/hono/test/smoke/outfits.smoke.test.ts
@@ -153,6 +153,7 @@ describe('[Smoke] Outfits: Seeded [basic-small-seed]', () => {
       }
     }
     expect(Array.isArray(resJSON.suggestions)).toBe(true)
+
     // Validate scoring details structure and types
     const scoringDetails = resJSON.suggestions[0].scoring_details
     expect(scoringDetails).toBeDefined()
@@ -160,17 +161,23 @@ describe('[Smoke] Outfits: Seeded [basic-small-seed]', () => {
     // Validate score values match expected ranges and types
     expect(scoringDetails.base_score).toBeGreaterThanOrEqual(0)
     expect(scoringDetails.base_score).toBeLessThanOrEqual(60) // Max rating (4) * 15
+
     expect(scoringDetails.items_score).toBeGreaterThanOrEqual(0)
     expect(scoringDetails.items_score).toBeLessThanOrEqual(32) // Max rating (4) * 8
+
     expect(scoringDetails.time_factor).toBeGreaterThanOrEqual(-10)
     expect(scoringDetails.time_factor).toBeLessThanOrEqual(20)
+
     expect(scoringDetails.frequency_score).toBeGreaterThanOrEqual(0)
-    expect(scoringDetails.frequency_score).toBeLessThanOrEqual(20)
+    expect(scoringDetails.frequency_score).toBeLessThanOrEqual(20) // Never worn bonus
+
     expect(scoringDetails.day_of_week_score).toBeGreaterThanOrEqual(0)
-    expect(scoringDetails.day_of_week_score).toBeLessThanOrEqual(15)
+    expect(scoringDetails.day_of_week_score).toBeLessThanOrEqual(15) // Max confidence * 15
+
     expect(scoringDetails.seasonal_score).toBeGreaterThanOrEqual(0)
-    expect(scoringDetails.seasonal_score).toBeLessThanOrEqual(15)
-    expect(scoringDetails.similarity_penalty).toBeGreaterThanOrEqual(-45)
+    expect(scoringDetails.seasonal_score).toBeLessThanOrEqual(15) // Max seasonal relevance * 15
+
+    expect(scoringDetails.similarity_penalty).toBeGreaterThanOrEqual(-125) // Max penalty for 4+ items
     expect(scoringDetails.similarity_penalty).toBeLessThanOrEqual(0)
 
     // Validate total score is sum of all components
@@ -187,6 +194,7 @@ describe('[Smoke] Outfits: Seeded [basic-small-seed]', () => {
     // Validate raw data structure and types
     const rawData = scoringDetails.raw_data
     expect(rawData).toBeDefined()
+
     expect(Number.isInteger(rawData.wear_count)).toBe(true)
     expect(rawData.wear_count).toBeGreaterThanOrEqual(0)
 
@@ -200,14 +208,15 @@ describe('[Smoke] Outfits: Seeded [basic-small-seed]', () => {
     expect(rawData.seasonal_relevance).toBeGreaterThanOrEqual(0)
     expect(rawData.seasonal_relevance).toBeLessThanOrEqual(1)
 
-    expect(Number.isInteger(rawData.similar_outfits_count)).toBe(true)
-    expect(rawData.similar_outfits_count).toBeGreaterThanOrEqual(0)
+    expect(Number.isInteger(rawData.recently_worn_items)).toBe(true)
+    expect(rawData.recently_worn_items).toBeGreaterThanOrEqual(0)
 
     expect(Array.isArray(rawData.core_items)).toBe(true)
     rawData.core_items.forEach((item) => {
       expect(typeof item).toBe('string')
       expect(item.length).toBe(24) // CUID length
     })
+
     expect(resJSON.generated_at).toBeDefined()
     expect(resJSON.metadata.wardrobe_size).toEqual(5)
     expect(resJSON.metadata.recency_threshold).toEqual(3)

--- a/hono/test/utils/factory/outfits.ts
+++ b/hono/test/utils/factory/outfits.ts
@@ -31,7 +31,7 @@ export interface OutfitSuggestionAPI extends OutfitAPI {
       days_since_worn: number
       same_day_count: number
       seasonal_relevance: number
-      similar_outfits_count: number
+      recently_worn_items: number
       core_items: string[]
     }
   }


### PR DESCRIPTION
Upgraded the algorithm to count the number of recently worn items, and use that data to further penalize other outfits up until the recency threshold.