### PR TITLE
[ENG-241] feat: suggestion alg rebuild

### DIFF
--- a/hono/src/services/outfits.ts
+++ b/hono/src/services/outfits.ts
@@ -1,7 +1,7 @@
 import { getAuth } from '@hono/clerk-auth'
 import { zValidator } from '@hono/zod-validator'
 import { isCuid } from '@paralleldrive/cuid2'
-import { and, eq, gte, inArray, lt, sql } from 'drizzle-orm'
+import { and, eq, gte, inArray, sql } from 'drizzle-orm'
 import { createInsertSchema, createSelectSchema } from 'drizzle-zod'
 import { Hono } from 'hono'
 import { z } from 'zod'

--- a/hono/src/services/tags.ts
+++ b/hono/src/services/tags.ts
@@ -24,9 +24,10 @@ const selectTagSchema = createSelectSchema(tags, {
 const app = new Hono<{ Variables: Variables }>()
   .get('/', requireAuth, injectDB, async (c) => {
     const auth = getAuth(c)
+    const userId = auth?.userId || ''
 
     const tagsData = await c.get('db').query.tags.findMany({
-      where: eq(tags.userId, auth?.userId || ''),
+      where: eq(tags.userId, userId),
       orderBy: (tags, { asc }) => [asc(tags.name)],
     })
 
@@ -34,6 +35,7 @@ const app = new Hono<{ Variables: Variables }>()
   })
   .post('/', zValidator('json', insertTagSchema), requireAuth, injectDB, async (c) => {
     const auth = getAuth(c)
+    const userId = auth?.userId || ''
     const body = c.req.valid('json')
 
     return c.json(
@@ -43,7 +45,7 @@ const app = new Hono<{ Variables: Variables }>()
           .insert(tags)
           .values({
             ...body,
-            userId: auth?.userId || '',
+            userId,
           })
           .returning()
       )[0]
@@ -57,6 +59,7 @@ const app = new Hono<{ Variables: Variables }>()
     injectDB,
     async (c) => {
       const auth = getAuth(c)
+      const userId = auth?.userId || ''
       const params = c.req.valid('param')
       const body = c.req.valid('json')
 
@@ -67,7 +70,7 @@ const app = new Hono<{ Variables: Variables }>()
             .update(tags)
             .set({
               ...body,
-              userId: auth?.userId || '',
+              userId,
             })
             .where(eq(tags.id, params.id))
             .returning()
@@ -82,6 +85,7 @@ const app = new Hono<{ Variables: Variables }>()
     injectDB,
     async (c) => {
       const auth = getAuth(c)
+      const userId = auth?.userId || ''
       const params = c.req.valid('param')
 
       return c.json(
@@ -89,7 +93,7 @@ const app = new Hono<{ Variables: Variables }>()
           await c
             .get('db')
             .delete(tags)
-            .where(and(eq(tags.id, params.id), eq(tags.userId, auth?.userId || '')))
+            .where(and(eq(tags.id, params.id), eq(tags.userId, userId)))
             .returning()
         )[0]
       )

--- a/hono/test/utils/factory/outfits.ts
+++ b/hono/test/utils/factory/outfits.ts
@@ -19,22 +19,29 @@ export interface OutfitAPI {
 
 export interface OutfitSuggestionAPI extends OutfitAPI {
   scoring_details: {
-    base_score: number
-    items_score: number
-    time_factor: number
-    frequency_score: number
-    day_of_week_score: number
-    seasonal_score: number
+    ratingScore: number
+    timeScore: number
+    frequencyScore: number
     total_score: number
-    raw_data: {
-      wear_count: number
-      days_since_worn: number
-      same_day_count: number
-      seasonal_relevance: number
-      recently_worn_items: number
-      core_items: string[]
+    rawData: {
+      daysSinceWorn: number
+      itemCount: number
+      nonAccessoryItemCount: number
+      wearCount: number
+      avgItemFreshness: string
+      minItemFreshness: string
+      typeWeightedFreshness: string
+      recentlyWornItems: number
+      outfitFreshness: string
+      wardrobeRatios: {
+        layer: number
+        top: number
+        bottom: number
+        footwear: number
+      }
     }
   }
+  totalScore: number
 }
 
 export class OutfitFactory implements Outfit {

--- a/next/src/components/ItemList.tsx
+++ b/next/src/components/ItemList.tsx
@@ -6,9 +6,10 @@ import { ItemListLoading } from './ItemListLoading'
 interface ItemListProps {
   itemsToOutfits: OutfitsResponse['outfits'][number]['itemsToOutfits']
   coreItems?: string[]
+  showLastWornAt?: boolean
 }
 
-export function ItemList({ itemsToOutfits, coreItems = [] }: ItemListProps) {
+export function ItemList({ itemsToOutfits, coreItems = [], showLastWornAt = false }: ItemListProps) {
   const { items, isLoading: isLoadingItems } = useItems()
 
   if (isLoadingItems) {
@@ -29,6 +30,7 @@ export function ItemList({ itemsToOutfits, coreItems = [] }: ItemListProps) {
               item={item}
               itemType={itemToOutfit.itemType as keyof typeof itemTypeIcons}
               isCoreItem={coreItems.includes(item.id)}
+              showLastWornAt={showLastWornAt}
             />
           </li>
         )

--- a/next/src/components/OutfitSuggestionsLoading.tsx
+++ b/next/src/components/OutfitSuggestionsLoading.tsx
@@ -1,11 +1,22 @@
 import { OutfitSuggestionsCardLoading } from './OutfitSuggestionsCardLoading'
+import { Skeleton } from "@/components/ui/skeleton"
 
 export default function OutfitListLoading() {
   return (
-    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 fade-out-br">
-      {[...Array(9)].map((_, index) => (
-        <OutfitSuggestionsCardLoading key={`suggestion-skeleton-${index}`}/>
-      ))}
+    <div className="space-y-6">
+      {/* Tags filter section loading state */}
+      <div className="flex flex-wrap gap-2">
+        {[...Array(6)].map((_, i) => (
+          <Skeleton key={i} className="h-6 w-16 rounded-md" />
+        ))}
+      </div>
+      
+      {/* Suggestions grid loading state */}
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {[...Array(9)].map((_, index) => (
+          <OutfitSuggestionsCardLoading key={`suggestion-skeleton-${index}`}/>
+        ))}
+      </div>
     </div>
   )
 } 


### PR DESCRIPTION
This PR introduces a new outfit recommendation algorithm and updates multiple components and tests to support refined scoring details, tag filtering, and pagination improvements. Key changes include:

- Enhancing UI loading states and integrating a tags filter for outfit suggestions.
- Updating client-side API calls and pagination logic to include tag-based filtering and revised page size.
- Modifying the scoring schema and related tests in both server and client code to accommodate new fields.

 I'm very well aware that the code is chunky. Closes ENG-241.